### PR TITLE
feat(admin): daily cost dashboard (list + sales input + live lratio)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "react-router-dom": "^7.8.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -1617,6 +1618,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2492,6 +2502,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.2.tgz",
+      "integrity": "sha512-7M2fR1JbIZ/jFWqelpvSZx+7vd7UlBTfdZqf6OSdF9g6+sfdqJDAWcak6ervbHph200ePlu+7G8LdoiC3ReyAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.8.2.tgz",
+      "integrity": "sha512-Z4VM5mKDipal2jQ385H6UBhiiEDlnJPx6jyWsTYoZQdl5TrjxEV2a9yl3Fi60NBJxYzOTGTTHXPi0pdizvTwow==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.8.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2558,6 +2606,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^7.8.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -44,3 +44,58 @@ export async function getDaily(userId: number, date: string) {
     status:"open"|"closed"|"not_started"|"inconsistent_data";
   }>;
 }
+
+// 日別：人件費の一覧＋合計（管理者）
+export async function getDailyTotal(date: string) {
+  const u = new URL(`${BASE}/v1/payroll/daily_total`);
+  u.searchParams.set("date", date);
+  const r = await fetch(u.toString(), { headers: authHeader() });
+  if (!r.ok) throw new Error(`GET /daily_total ${r.status}`);
+  // 期待レスポンス
+  // { date, raws: [ { user_id, name, work_minutes, break_minutes, night_minutes, base_hourly_wage, total_wage } ], total_total_wage }
+  return r.json() as Promise<{
+    date: string;
+    rows: Array<{
+      user_id:number;
+      user_name:string;
+      base_hourly_wage:number;
+      work_minutes:number;
+      break_minutes:number;
+      night_minutes:number;
+      daily_wage:number;
+    }>;
+    total_daily_wage: number;
+  }>;
+}
+
+// 売上　取得/保存（管理者）
+export async function getSales(date: string) {
+  const u = new URL(`${BASE}/v1/sales`);
+  u.searchParams.set("date", date);
+  const r = await fetch(u.toString(), { headers: authHeader() });
+  if (!r.ok) throw new Error(`GET /v1/sales ${r.status}`);
+  return r.json() as Promise<{ date: string; amount_yen: number | null; note: string | null }>;
+}
+
+export async function putSales(date: string, amount_yen: number, note?: string) {
+  const u = new URL(`${BASE}/v1/sales`);
+  u.searchParams.set("date", date);
+  const body = new URLSearchParams({ amount_yen: String(amount_yen) });
+  if (note) body.set("note", note);
+  const r = await fetch(u.toString(), {
+    method: "PUT",
+    headers: { ...authHeader(), "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8" },
+    body,
+  });
+  if (!r.ok) throw new Error(`PUT /v1/sales ${r.status}`);
+  return r.json() as Promise<{ id: number; date: string; amount_yen: number; note?: string | null }>;
+}
+
+// LRatio（管理者）
+export async function getLRatio(date: string) {
+  const u = new URL(`${BASE}/v1/l_ratio/daily`);
+  u.searchParams.set("date", date);
+  const r = await fetch(u.toString(), { headers: authHeader() });
+  if (!r.ok) throw new Error(`GET /v1/l_ratio/daily ${r.status}`);
+  return r.json() as Promise<{ date: string; daily_sales: number | null; total_daily_wage: number; l_ratio: number | null }>;
+}

--- a/src/pages/AdminHomePage.tsx
+++ b/src/pages/AdminHomePage.tsx
@@ -1,0 +1,162 @@
+// すでにログイン・adminチェックを通過している前提のメイン領域を差し替え
+import { useEffect, useMemo, useState } from "react";
+import { getDailyTotal, getSales, putSales, getLRatio } from "../lib/api.ts";
+
+function fmtYen(n: number | null | undefined) {
+  if (n == null) return "-";
+  return n.toLocaleString("ja-JP") + " 円";
+}
+function minutesToHM(min: number) {
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  return `${h}時間${m}分`;
+}
+
+export default function AdminHomePage() {
+  const [date, setDate] = useState<string>(new Date().toISOString().slice(0, 10));
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  // 人件費一覧
+  const [rows, setRows] = useState<
+    Awaited<ReturnType<typeof getDailyTotal>>["rows"]
+  >([]);
+  const [totalWage, setTotalWage] = useState<number>(0);
+
+  // 売上
+  const [sales, setSales] = useState<number | null>(null);
+  const [note, setNote] = useState<string>("");
+
+  // 比率
+  const [ratio, setRatio] = useState<number | null>(null);
+
+  async function refreshAll(d = date) {
+    try {
+      setLoading(true);
+      setErr(null);
+      const [t, s, r] = await Promise.all([
+        getDailyTotal(d),
+        getSales(d),
+        getLRatio(d),
+      ]);
+      setRows(t.rows);
+      setTotalWage(t.total_daily_wage);
+
+      setSales(s.amount_yen);
+      setNote(s.note ?? "");
+
+      setRatio(r.l_ratio);
+    } catch (e: any) {
+      setErr(e?.message ?? "fetch failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    refreshAll(date);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [date]);
+
+  async function saveSales() {
+    try {
+      setLoading(true);
+      setErr(null);
+      await putSales(date, Number(sales ?? 0), note || undefined);
+      // 保存後、最新の比率を再計算して反映
+      const r = await getLRatio(date);
+      setRatio(r.l_ratio);
+    } catch (e: any) {
+      setErr(e?.message ?? "save failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const monthLabel = useMemo(() => {
+    const d = new Date(date);
+    return `${d.getFullYear()}年${d.getMonth() + 1}月`;
+  }, [date]);
+
+  return (
+    <div style={{ maxWidth: 1100, margin: "2rem auto", padding: 16, display: "grid", gap: 16, gridTemplateColumns: "1fr 320px" }}>
+      <div>
+        <header style={{ display: "flex", gap: 12, alignItems: "end" }}>
+          <div>
+            <label>日付</label><br />
+            <input type="date" value={date} onChange={(e) => setDate(e.target.value)} />
+          </div>
+          <button onClick={() => refreshAll()} disabled={loading}>
+            {loading ? "更新中…" : "再計算"}
+          </button>
+          <div style={{ marginLeft: "auto", opacity: 0.7 }}>{monthLabel}</div>
+        </header>
+
+        {err && <p style={{ color: "tomato", marginTop: 8 }}>{err}</p>}
+
+        <section style={{ marginTop: 12 }}>
+          <h3>人件費一覧</h3>
+          <table width="100%" cellPadding={6} style={{ borderCollapse: "collapse", border: "1px solid #eee" }}>
+            <thead>
+              <tr>
+                <th align="left">ユーザー</th>
+                <th align="right">実働</th>
+                <th align="right">休憩</th>
+                <th align="right">深夜</th>
+                <th align="right">基本時給</th>
+                <th align="right">日額人件費</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <tr key={r.user_id} style={{ borderTop: "1px solid #f0f0f0" }}>
+                  <td>{r.user_name} (ID:{r.user_id})</td>
+                  <td align="right">{minutesToHM(r.work_minutes)}</td>
+                  <td align="right">{minutesToHM(r.break_minutes)}</td>
+                  <td align="right">{minutesToHM(r.night_minutes)}</td>
+                  <td align="right">{fmtYen(r.base_hourly_wage)}</td>
+                  <td align="right"><b>{fmtYen(r.daily_wage)}</b></td>
+                </tr>
+              ))}
+              {rows.length === 0 && (
+                <tr>
+                  <td colSpan={6} style={{ textAlign: "center", padding: 16, color: "#666" }}>
+                    当日の勤務データがありません
+                  </td>
+                </tr>
+              )}
+            </tbody>
+            <tfoot>
+              <tr style={{ borderTop: "2px solid #ddd"}}>
+                <td colSpan={5} align="right">合計</td>
+                <td align="right"><b>{fmtYen(totalWage)}</b></td>
+              </tr>
+            </tfoot>
+          </table>
+        </section>
+      </div>
+
+      <aside style={{ border: "1px solid #eee", borderRadius: 8, padding: 12 }}>
+        <h3>売上入力</h3>
+        <div style={{ display: "grid", gap: 8 }}>
+          <label>金額（円）</label>
+          <input
+            type="number"
+            value={sales ?? ""}
+            onChange={(e) => setSales(e.target.value === "" ? null : Number(e.target.value))}
+          />
+          <label>メモ（任意）</label>
+          <textarea value={note} onChange={(e) => setNote(e.target.value)} rows={4} />
+          <button onClick={saveSales} disabled={loading}>{loading ? "保存中…" : "保存"}</button>
+        </div>
+
+        <div style={{ marginTop: 16 }}>
+          <h4>売上対人件費（即時計算）</h4>
+          <p>売上：<b>{fmtYen(sales)}</b></p>
+          <p>人件費合計：<b>{fmtYen(totalWage)}</b></p>
+          <p>比率：<b>{ratio == null ? "-" : `${(ratio * 100).toFixed(2)} %`}</b></p>
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,0 +1,64 @@
+// src/pages/LoginPage.tsx
+
+import { useState } from "react";
+import { login } from "../lib/api";
+
+type Props = {
+  onLoginSuccess: (token: string) => void;
+  initialError: string | null;
+};
+
+export default function LoginPage({ onLoginSuccess, initialError }: Props) {
+  const [email, setEmail] = useState("admin@example.com");
+  const [password, setPassword] = useState("adminpass");
+  const [loginBusy, setLoginBusy] = useState(false);
+  const [authErr, setAuthErr] = useState<string | null>(initialError);
+
+  // ログイン処理
+  async function doLogin(e: React.FormEvent) {
+    e.preventDefault();
+    try {
+      setLoginBusy(true);
+      setAuthErr(null);
+      const res = await login(email, password);
+      onLoginSuccess(res.token);
+    } catch (e: any) {
+      setAuthErr(e?.message ?? "ログインに失敗しました");
+    } finally {
+      setLoginBusy(false);
+    }
+  }
+
+  return (
+    <div style={{ maxWidth: 420, margin: "6rem auto", padding: 16 }}>
+      <h1>勤怠（管理者）ログイン</h1>
+      <form onSubmit={doLogin} style={{ marginTop: 16 }}>
+        <div>
+          <label>メール</label>
+          <br />
+          <input
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            autoComplete="username"
+            style={{ width: "100%" }}
+          />
+        </div>
+        <div style={{ marginTop: 8 }}>
+          <label>パスワード</label>
+          <br />
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            autoComplete="current-password"
+            style={{ width: "100%" }}
+          />
+        </div>
+        <button type="submit" disabled={loginBusy} style={{ marginTop: 12 }}>
+          {loginBusy ? "ログイン中…" : "ログイン"}
+        </button>
+      </form>
+      {authErr && <p style={{ color: "tomato", marginTop: 8 }}>{authErr}</p>}
+    </div>
+  );
+}

--- a/src/pages/TimeEntrySearchPage.tsx
+++ b/src/pages/TimeEntrySearchPage.tsx
@@ -1,0 +1,94 @@
+// src/pages/TimeEntrySearchPage.tsx
+
+import { useState } from "react";
+import { getEntries, getDaily } from "../lib/api";
+
+type Entry = Awaited<ReturnType<typeof getEntries>>[number];
+type Daily = Awaited<ReturnType<typeof getDaily>>;
+
+function fmt(t: string | null) {
+  if (!t) return "-";
+  const d = new Date(t);
+  return d.toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" });
+}
+
+function minutesToHM(min: number) {
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  return `${h}時間${m}分`;
+}
+
+export default function TimeEntrySearchPage() {
+  const [userId, setUserId] = useState(1);
+  const [date, setDate] = useState<string>(new Date().toISOString().slice(0,10)); // YYYY-MM-DD
+  const [entries, setEntries] = useState<Entry[]>([]);
+  const [daily, setDaily] = useState<Daily | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  async function search() {
+      try {
+        setLoading(true);
+        setErr(null);
+        const [e, d] = await Promise.all([getEntries(userId, date), getDaily(userId, date)]);
+        setEntries(e);
+        setDaily(d);
+      } catch (e:any) {
+        setErr(e.message ?? "fetch failed");
+      } finally {
+        setLoading(false);
+      }
+  }
+
+  return (
+    <div style={{maxWidth:900,margin:"2rem auto",padding:16}}>
+      <h1>勤怠検索（管理者）</h1>
+
+      <section style={{display:"flex",gap:12,alignItems:"end"}}>
+        <div>
+          <label>ユーザーID</label><br/>
+          <input type="number" value={userId} onChange={e=>setUserId(Number(e.target.value))} />
+        </div>
+        <div>
+          <label>日付</label><br/>
+          <input type="date" value={date} onChange={e=>setDate(e.target.value)} />
+        </div>
+        <button onClick={search} disabled={loading}>検索</button>
+      </section>
+
+      {err && <p style={{color:"tomato"}}>{err}</p>}
+
+      <section style={{marginTop:16,padding:12,border:"1px solid #ddd",borderRadius:8}}>
+        <h3>日次サマリ</h3>
+        {daily ? (
+          <ul>
+            <li>status: <b>{daily.status}</b></li>
+            <li>start: {fmt(daily.actual.start)}</li>
+            <li>end: {fmt(daily.actual.end)}</li>
+            <li>work: {daily.totals.work} 分 / break: {daily.totals.break} 分</li>
+          </ul>
+        ) : <p>データがありません</p>}
+      </section>
+
+      <section style={{marginTop:16}}>
+        <h3>打刻一覧</h3>
+        <table width="100%" cellPadding={6} style={{borderCollapse:"collapse"}}>
+          <thead>
+            <tr><th align="left">ID</th><th align="left">種別</th><th align="left">時刻</th><th align="left">source</th></tr>
+          </thead>
+          <tbody>
+            {entries.map(e=>(
+              <tr key={e.id} style={{borderTop:"1px solid #eee"}}>
+                <td>{e.id}</td>
+                <td>{e.kind}</td>
+                <td>{fmt(e.happened_at)}</td>
+                <td>{e.source}</td>
+              </tr>
+            ))}
+            {entries.length===0 && <tr><td colSpan={4}>データなし</td></tr>}
+          </tbody>
+        </table>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
# feat: 管理者画面の刷新とコンポーネント分割による構造改善

## 概要

管理者向けアプリケーションのフロントエンド構造を全面的に刷新しました。

これまで単一のファイルに実装されていた全機能を、`react-router-dom`を導入してページ単位のコンポーネントに分割しました。また、新しいメインページとして、その日の人件費や売上を一覧できるダッシュボード画面を実装しました。

## 背景

旧来の実装は、すべてのロジックが`App.tsx`に集中しており、将来的な機能拡張やメンテナンスが困難な状態でした。

今回のリファクタリングにより、各ページの関心を分離し、見通しが良く、拡張性の高いアーキテクチャを実現することを目的としています。

## 主な変更点

- **`react-router-dom`の導入**
  - URLに基づいたページ遷移を管理するために、`react-router-dom`を導入しました。
  - これにより、各ページが固有のURL（`/`, `/search`など）を持つようになり、ブックマークやブラウザの「戻る」ボタンが機能するようになります。

- **`App.tsx`の役割変更**
  - `App.tsx`の責務を、UIの表示から**ルーターと認証状態の管理**（司令塔）に変更しました。
  - ログイン状態やユーザー権限（`role`）を一元管理し、URLに応じて適切なページコンポーネントを表示します。

- **ページコンポーネントの分割**
  - 以下の3つの主要なページコンポーネントを`src/pages/`ディレクトリに作成しました。
    - `LoginPage.tsx`: ログイン機能
    - `AdminHomePage.tsx`: 新しいメインのダッシュボード画面
    - `TimeEntrySearchPage.tsx`: 既存の勤怠検索画面

- **新ホーム画面（ダッシュボード）の実装**
  - 管理者がログイン後に最初に表示するページ（`/`）を、新しい`AdminHomePage`に変更しました。
  - この画面では、指定した日付の全従業員の勤務状況、日額人件費、およびその合計を一覧で確認できます。
  - また、その日の売上を入力・保存し、売上対人件費比率をリアルタイムで確認する機能も追加しました。

- **認証・認可ロジックの強化**
  - `AdminRoute`という保護ルートを実装し、管理者権限を持たないユーザーが管理者向けページにアクセスしようとした場合、適切に権限エラーページへリダイレクトするようにしました。

## 確認方法

1.  アプリケーションを起動し、`/login`にアクセスするとログイン画面が表示されることを確認してください。
2.  管理者アカウント（`admin@example.com`）でログインすると、新しいダッシュボード画面（`AdminHomePage`）にリダイレクトされることを確認してください。
3.  ヘッダーのナビゲーションリンク（「ホーム」「勤怠検索」）をクリックして、ページが正しく切り替わることを確認してください。
4.  従業員アカウントでログインしようとすると、「権限がありません」ページにリダイレクトされ、ログアウトできることを確認してください。
5.  どのページからでも、ヘッダーの「ログアウト」ボタンで正常にログアウトできることを確認してください。